### PR TITLE
useful tag name for MRs, added imageTagPrefix and imageTagSuffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Build and publish your repository as a Docker image and push it to GitHub Packag
 
 *Optional*. The desired tag for the image. Defaults to current branch or release version number.
 
+### `imageTagPrefix`
+
+*Optional*. Added to the beginning of the tag.
+
+### `imageTagSuffix`
+
+*Optional*. Added to the end of the tag.
+
 ### `buildArguments`
 
 *Optional*. Any additional build arguments to use when building the image.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
   imageTag:
     description: "The desired tag for the image. Defaults to current branch or release version number."
     required: false
+  imageTagPrefix:
+    description: "Added to the beginning of the tag."
+    required: false
+  imageTagSuffix:
+    description: "Added to the end of the tag."
+    required: false
   buildArguments:
     description: "The build arguments for image."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -693,7 +693,18 @@ async function run() {
     let imageTag = core.getInput('imageTag', { required: false });
     const ref = process.env['GITHUB_REF'];
     const refArray = ref.split('/');
-    if (!imageTag) imageTag = refArray[refArray.length - 1];
+    if (!imageTag) {
+        const refLast = refArray[refArray.length - 1];
+        if (refLast === "merge" && refArray.length >= 2) {
+            imageTag = "mr" + refArray[refArray.length - 2];
+        } else {
+            imageTag = refLast;
+        }
+    }
+    let imageTagPrefix = core.getInput('imageTagPrefix', { required: false });
+    if (imageTagPrefix) imageName = imageTagPrefix + imageName;
+    let imageTagSuffix = core.getInput('imageTagSuffix', { required: false });
+    if (imageTagSuffix) imageName = imageName + imageTagSuffix;
 
     // Set some variables.
     const imageURL = `docker.pkg.github.com/${repository}/${imageName}:${imageTag}`


### PR DESCRIPTION
- Useful tag name for MRs: `mrID` (e.g.: `mr1`)
- added `imageTagPrefix` and `imageTagSuffix` options