### PR TITLE
Drop GitHub Package Registry in favour of GitHub Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,33 @@
 # GitHub Docker Action
 
-Build and publish your repository as a Docker image and push it to GitHub Package Registry or GitHub Container Registry in one easy step.
+Build and publish your repository as a Docker image and push it to GitHub Container Registry in one easy step.
 
 [![GitHub Release](https://img.shields.io/github/v/release/matootie/github-docker)](https://github.com/matootie/github-docker/releases/latest)
 
-For help updating, view the [change logs](https://github.com/matootie/github-docker/releases). If you need additional help feel free to submit an issue.
+Before updating, view the [change logs](https://github.com/matootie/github-docker/releases). If you need help feel free to submit an issue.
 
 ## Table of Contents
 
 - [**Inputs**](#inputs)
 - [**Outputs**](#outputs)
-- [**GitHub Package Registry**](#github-package-registry-usage)
+- [**Examples**](#examples)
   - [Simple usage](#simple-minimal-usage)
   - [Custom tag](#publishing-using-custom-tag)
   - [Multiple tags](#publishing-using-several-tags)
   - [Build arguments](#publishing-using-build-arguments)
   - [Using output](#publishing-and-using-output)
   - [Custom context](#publishing-using-custom-context)
-  - [Publishing to a different repository](#publishing-to-a-different-repository)
-- [**GitHub Container Registry**](#github-container-registry-usage)
-  - [Simple usage](#simple-minimal-usage-1)
-  - [Custom tag](#publishing-using-custom-tag-1)
-  - [Multiple tags](#publishing-using-several-tags-1)
-  - [Build arguments](#publishing-using-build-arguments-1)
-  - [Using output](#publishing-and-using-output-1)
-  - [Custom context](#publishing-using-custom-context-1)
 
 ## Inputs
 
 | Name                  | Requirement       | Description |
 | --------------------- | ----------------- | ------------|
-| `accessToken`        | **Required**       | GitHub Access Token to log in using. Must have write permissions for packages. Recommended set up would be to use the provided GitHub Token for your repository; `${{ github.token }}`.
+| `accessToken`        | **Required**       | GitHub Access Token to log in using. Must have write permissions for packages.
 | `imageName`           | ***Optional***    | The desired name for the image. Defaults to current repository name.
 | `tag`                 | ***Optional***    | The desired tag for the image. Defaults to `latest`. Optionally accepts multiple tags separated by newline. _See [example below](#publishing-using-several-tags)_.
 | `buildArgs`           | ***Optional***    | Any additional build arguments to use when building the image, separated by newline. _See [example below](#publishing-using-build-arguments)_.
 | `context`             | ***Optional***    | Where should GitHub Docker find the Dockerfile? This is a path relative to the repository root. Defaults to `.`, meaning it will look for a `Dockerfile` in the root of the repository. _See [example below](#publishing-using-custom-context)_.
 | `contextName`         | ***Optional***    | What Dockerfile should GitHub Docker be using when building. Defaults to traditional `Dockerfile` name. _See [example below](#publishing-using-custom-context)_.
-| `containerRegistry`   | ***Optional***    | Whether or not to push to GitHub Container Registry instead of GitHub Package Registry. _When using GitHub Container Registry there are a few important differences to keep in mind. See [explanation below](#github-container-registry-usage)_.
-| `repository`          | ***Optional***    | The repository to push the image to. Defaults to the current repository. Must be specified in format `user/repo`. _Note: Using an external repository requires elevated permissions. The provided GitHub token for the repository running the action will **not** suffice. You must use custom secret containing a [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) that has package write permissions on the given repository. See [example below](#publishing-to-a-different-repository)_.
 
 ## Outputs
 
@@ -45,18 +35,18 @@ For help updating, view the [change logs](https://github.com/matootie/github-doc
 | --------------------- | ------------------------------------------ |
 | `imageURL`            | The URL of the image, **without** the tag. |
 
-## GitHub Package Registry usage
+## Examples
 
 #### Simple, minimal usage...
 
 ```yaml
 - name: Publish Image
-  uses: matootie/github-docker@v3.1.0
+  uses: matootie/ghcr@v4.0.0
   with:
-    accessToken: ${{ github.token }}
+    accessToken: ${{ secrets.GHCR_TOKEN }}
 ```
 
-That's right this is all you need to get started with GitHub Docker, simply provide the GitHub token and the defaults will go to work. An image following the repository name will be pushed to the repository, tagged with `latest`. The resulting URL is set as output for easy use in future steps!
+That's right this is all you need to get started with this action! Simply provide the GitHub access token and the defaults will go to work. An image following the repository name will be pushed to GitHub Container Registry under the repository owner, tagged with `latest`. The resulting URL is set as output for easy use in future steps!
 
 For additional customizations, see further examples below. For more information on the output URL, see [this example](#publishing-and-using-output).
 
@@ -64,9 +54,9 @@ For additional customizations, see further examples below. For more information 
 
 ```yaml
 - name: Publish Image
-  uses: matootie/github-docker@v3.1.0
+  uses: matootie/ghcr@v4.0.0
   with:
-    accessToken: ${{ github.token }}
+    accessToken: ${{ secrets.GHCR_TOKEN }}
     tag: latest
 ```
 
@@ -76,9 +66,9 @@ In this example we specify a custom tag for the image. Remember to append the ta
 
 ```yaml
 - name: Publish Image
-  uses: matootie/github-docker@v3.1.0
+  uses: matootie/ghcr@v4.0.0
   with:
-    accessToken: ${{ github.token }}
+    accessToken: ${{ secrets.GHCR_TOKEN }}
     tag: |
       latest
       ${{ github.sha }}
@@ -90,9 +80,9 @@ In this example we publish the same image under two different tags.
 
 ```yaml
 - name: Publish Image
-  uses: matootie/github-docker@v3.1.0
+  uses: matootie/ghcr@v4.0.0
   with:
-    accessToken: ${{ github.token }}
+    accessToken: ${{ secrets.GHCR_TOKEN }}
     buildArgs: |
       ENVIRONMENT=test
       SOME_OTHER_ARG=yes
@@ -104,10 +94,10 @@ Using build arguments is easy, just set each one on its own individual line, sim
 
 ```yaml
 - name: Publish Image
-  uses: matootie/github-docker@v3.1.0
+  uses: matootie/ghcr@v4.0.0
   id: publish
   with:
-    accessToken: ${{ github.token }}
+    accessToken: ${{ secrets.GHCR_TOKEN }}
 
 - name: Print Image URL
   run: echo ${{ steps.publish.outputs.imageURL }}    
@@ -117,150 +107,27 @@ In this example you can see how easy it is to reference the image URL after publ
 
 ```yaml
 - name: Publish Image
-  uses: matootie/github-docker@v3.1.0
+  uses: matootie/ghcr@v4.0.0
   id: publish
   with:
-    accessToken: ${{ github.token }}
+    accessToken: ${{ secrets.GHCR_TOKEN }}
     tag: ${{ github.sha }}
 
 - name: Print Full Image URL
   run: echo ${{ stets.publish.outputs.imageURL }}:${{ github.sha }}
 ```
 
-Otherwise, future steps will end up using the literal tag `latest` for the image and not the customized tag.
+Otherwise, future steps will end up using the implicit tag `latest` for the image and not the customized tag.
 
 #### Publishing using custom context...
 
 ```yaml
 - name: Publish Image
-  uses: matootie/github-docker@v3.1.0
+  uses: matootie/ghcr@v4.0.0
   with:
-    accessToken: ${{ github.token }}  
+    accessToken: ${{ secrets.GHCR_TOKEN }}  
     context: custom/context/dir/
     contextName: custom.Dockerfile
 ```
 
-Here we see an example where GitHub Docker is given additional context on how to find the right Dockerfile. `context` is used to specify the directory of the Dockerfile, and `contextName` is used if the name of the Dockerfile is something that different than what `docker build .` would find.
-
-#### Publishing to a different repository.
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  with:
-    accessToken: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-    repository: my-user/my-repo
-```
-
-In this example we're pushing the resulting image to be listed under a separate repository, different from the one that this action is running on. Remember, in this case the provided `${{ github.token }}` will **not** work as it only has the necessary permissions for its own repository. You need to save a GitHub [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) with write permissions to packages as a secret, and use that.
-
-## GitHub Container Registry usage
-
-Using GitHub Docker with the GitHub Container Registry is just about the same as using it with the Package Registry, but there are a few things to remember.
-
-1. The `accessToken` input must be a [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) with `write:packages` scope.
-2. The `repositoryName` input is entirely useless as the container will be pushed to the owner of the current repository instead.
-
-The following are a copy of the same examples listed above, using GitHub Container Registry instead of GitHub Package Registry. _Note the differences in input_.
-
-#### Simple, minimal usage...
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  with:
-    accessToken: ${{ secrets.PAT }}
-    containerRegistry: true
-```
-
-That's right this is all you need to get started with GitHub Docker, simply provide the GitHub token and the defaults will go to work. An image following the repository name will be pushed to the repository owner, tagged with `latest`. The resulting URL is set as output for easy use in future steps!
-
-For additional customizations, see further examples below. For more information on the output URL, see [this example](#publishing-and-using-output-1).
-
-#### Publishing using custom tag...
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  with:
-    accessToken: ${{ secrets.PAT }}
-    tag: latest
-    containerRegistry: true
-```
-
-In this example we specify a custom tag for the image. Remember to append the tag when using the outputted image URL in the workflow. See [this example](#publishing-and-using-output-1) for more details.
-
-#### Publishing using several tags...
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  with:
-    accessToken: ${{ secrets.PAT }}
-    tag: |
-      latest
-      ${{ github.sha }}
-    containerRegistry: true
-```
-
-In this example we publish the same image under two different tags.
-
-#### Publishing using build arguments...
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  with:
-    accessToken: ${{ secrets.PAT }}
-    buildArgs: |
-      ENVIRONMENT=test
-      SOME_OTHER_ARG=yes
-    containerRegistry: true
-```
-
-Using build arguments is easy, just set each one on its own individual line, similarly to how you would in a `.env` file.
-
-#### Publishing and using output...
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  id: publish
-  with:
-    accessToken: ${{ secrets.PAT }}
-    containerRegistry: true
-
-- name: Print Image URL
-  run: echo ${{ steps.publish.outputs.imageURL }}    
-```
-
-In this example you can see how easy it is to reference the image URL after publishing. If you are using a custom tag, you most likely are going to need to append the tag to the URL when using it in the workflow...
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  id: publish
-  with:
-    accessToken: ${{ secrets.PAT }}
-    tag: ${{ github.sha }}
-    containerRegistry: true
-
-- name: Print Full Image URL
-  run: echo ${{ stets.publish.outputs.imageURL }}:${{ github.sha }}
-```
-
-Otherwise, future steps will end up using the literal tag `latest` for the image and not the customized tag.
-
-#### Publishing using custom context...
-
-```yaml
-- name: Publish Image
-  uses: matootie/github-docker@v3.1.0
-  with:
-    accessToken: ${{ secrets.PAT }}  
-    context: custom/context/dir/
-    contextName: custom.Dockerfile
-    containerRegistry: true
-```
-
-Here we see an example where GitHub Docker is given additional context on how to find the right Dockerfile. `context` is used to specify the directory of the Dockerfile, and `contextName` is used if the name of the Dockerfile is something that different than what `docker build .` would find.
+Here we see an example of how to provide additional context to find the right Dockerfile. `context` is used to specify the directory of the Dockerfile, and `contextName` is used if the name of the Dockerfile is something that different than what `docker build .` would find by default.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "GitHub Docker Action"
-description: "Build and publish your repository as a Docker image and push it to GitHub Package Registry in one step"
+description: "Build and publish your repository as a Docker image and push it to GitHub Container Registry in one easy step"
 inputs:
   accessToken:
     description: "GitHub Repository Token to log in using."
@@ -22,13 +22,6 @@ inputs:
     description: "What Dockerfile should GitHub Docker be using when building. Defaults to traditional Dockerfile name."
     required: false
     default: Dockerfile
-  containerRegistry:
-    description: "Whether or not to push to GitHub Container Registry instead of GitHub Package Registry."
-    required: false
-    default: "false"
-  repository:
-    description: "The repository to push the image to. Defaults to the current repository. Must be specified in format user/repo."
-    required: false
 outputs:
   imageURL:
     description: "The URL of the image, without the tag."

--- a/dist/index.js
+++ b/dist/index.js
@@ -934,10 +934,72 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
+/***/ 82:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
+
+/***/ }),
+
 /***/ 87:
 /***/ (function(module) {
 
 module.exports = require("os");
+
+/***/ }),
+
+/***/ 102:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(747));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
 
 /***/ }),
 
@@ -961,8 +1023,6 @@ async function run() {
     const buildArgsRaw = core.getInput("buildArgs", { required: false });
     const contextRaw = core.getInput("context", { required: true });
     const contextNameRaw = core.getInput("contextName", { required: false });
-    const crRaw = core.getInput("containerRegistry", { required: true });
-    const repositoryRaw = core.getInput("repository", { required: false });
 
     /* =========================================================================
         SET ALL DEFAULTS
@@ -980,20 +1040,11 @@ async function run() {
       contextNameRaw
     );
 
-    const username = process.env.GITHUB_ACTOR;
-
     // The access token is as-is.
     const accessToken = accessTokenRaw;
 
     // Get the optional repository name.
-    let repository = repositoryRaw
-    if (!repository) {
-      repository = process.env.GITHUB_REPOSITORY;
-    }
-    repository = repository.toLowerCase();
-
-    // Decide whether or not we're pushing to container registry.
-    const containerRegistryEnabled = (crRaw == "true");
+    repository = process.env.GITHUB_REPOSITORY.toLowerCase();
 
     // Set some throwaway values.
     const repoArray = repository.split("/");
@@ -1013,12 +1064,7 @@ async function run() {
     if (buildArgsRaw) buildArgs = buildArgsRaw.match(/\w+=\S+/g).flatMap(str => ["--build-arg", str]);
 
     // Generate a base image URL.
-    let imageURL;
-    if (containerRegistryEnabled) {
-      imageURL = `ghcr.io/${ownerName}/${imageName}`;
-    } else {
-      imageURL = `docker.pkg.github.com/${repository}/${imageName}`;
-    }
+    const imageURL = `ghcr.io/${ownerName}/${imageName}`;
 
     // Process the image tags.
     let tags = ["--tag", "latest"];
@@ -1029,57 +1075,43 @@ async function run() {
     ========================================================================= */
 
     // Log in.
-    if (containerRegistryEnabled) {
-      await exec.exec(
-        "docker",
-        [
-          "login",
-          "ghcr.io",
-          "--username",
-          ownerName,
-          "--password",
-          accessToken
-        ]
-      );
-    } else {
-      await exec.exec(
-        "docker",
-        [
-          "login",
-          "docker.pkg.github.com",
-          "--username",
-          username,
-          "--password",
-          accessToken
-        ]
-      );
-    }
+    await exec.exec(
+      "docker",
+      [
+        "login",
+        "ghcr.io",
+        "--username",
+        ownerName,
+        "--password",
+        accessToken
+      ]
+    );
 
     /* =========================================================================
-        BUILD THE DOCKER IMAGES
+        BUILD THE DOCKER IMAGE(S)
     ========================================================================= */
 
     // Build the Docker image(s).
     await exec.exec(
-        "docker",
-        [
-          "build",
-          ...tags,
-          ...buildArgs,
-          "--file",
-          contextName,
-          context
-        ]
-      );
+      "docker",
+      [
+        "build",
+        ...tags,
+        ...buildArgs,
+        "--file",
+        contextName,
+        context
+      ]
+    );
 
     /* =========================================================================
-        PUSH THE DOCKER IMAGES
+        PUSH THE DOCKER IMAGE(S)
     ========================================================================= */
 
     // Push the Docker image(s).
     let pushTags = tags.filter((item, index) => index % 2 === 1);
     for (let pushImage of pushTags) {
-      await exec.exec("docker", [ "push", pushImage ]);
+      await exec.exec("docker", ["push", pushImage]);
     }
 
     /* =========================================================================
@@ -1118,17 +1150,25 @@ module.exports = require("assert");
 
 "use strict";
 
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-const os = __webpack_require__(87);
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
 /**
  * Commands
  *
  * Command Format:
- *   ##[name key=value;key=value]message
+ *   ::name key=value,key=value::message
  *
  * Examples:
- *   ##[warning]This is the user warning message
- *   ##[set-secret name=mypassword]definitelyNotAPassword!
+ *   ::warning::This is the message
+ *   ::set-env name=MY_VAR::some value
  */
 function issueCommand(command, properties, message) {
     const cmd = new Command(command, properties, message);
@@ -1164,30 +1204,28 @@ class Command {
                         else {
                             cmdStr += ',';
                         }
-                        // safely append the val - avoid blowing up when attempting to
-                        // call .replace() if message is not a string for some reason
-                        cmdStr += `${key}=${escape(`${val || ''}`)}`;
+                        cmdStr += `${key}=${escapeProperty(val)}`;
                     }
                 }
             }
         }
-        cmdStr += CMD_STRING;
-        // safely append the message - avoid blowing up when attempting to
-        // call .replace() if message is not a string for some reason
-        const message = `${this.message || ''}`;
-        cmdStr += escapeData(message);
+        cmdStr += `${CMD_STRING}${escapeData(this.message)}`;
         return cmdStr;
     }
 }
 function escapeData(s) {
-    return s.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
 }
-function escape(s) {
-    return s
+function escapeProperty(s) {
+    return utils_1.toCommandValue(s)
+        .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
-        .replace(/]/g, '%5D')
-        .replace(/;/g, '%3B');
+        .replace(/:/g, '%3A')
+        .replace(/,/g, '%2C');
 }
 //# sourceMappingURL=command.js.map
 
@@ -1207,10 +1245,19 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const command_1 = __webpack_require__(431);
-const os = __webpack_require__(87);
-const path = __webpack_require__(622);
+const file_command_1 = __webpack_require__(102);
+const utils_1 = __webpack_require__(82);
+const os = __importStar(__webpack_require__(87));
+const path = __importStar(__webpack_require__(622));
 /**
  * The code to exit an action
  */
@@ -1231,11 +1278,21 @@ var ExitCode;
 /**
  * Sets env variable for this action and future actions in the job
  * @param name the name of the variable to set
- * @param val the value of the variable
+ * @param val the value of the variable. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    process.env[name] = val;
-    command_1.issueCommand('set-env', { name }, val);
+    const convertedVal = utils_1.toCommandValue(val);
+    process.env[name] = convertedVal;
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -1251,7 +1308,13 @@ exports.setSecret = setSecret;
  * @param inputPath
  */
 function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;
@@ -1274,12 +1337,22 @@ exports.getInput = getInput;
  * Sets the value of an output.
  *
  * @param     name     name of the output to set
- * @param     value    value to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
     command_1.issueCommand('set-output', { name }, value);
 }
 exports.setOutput = setOutput;
+/**
+ * Enables or disables the echoing of commands into stdout for the rest of the step.
+ * Echoing is disabled by default if ACTIONS_STEP_DEBUG is not set.
+ *
+ */
+function setCommandEcho(enabled) {
+    command_1.issue('echo', enabled ? 'on' : 'off');
+}
+exports.setCommandEcho = setCommandEcho;
 //-----------------------------------------------------------------------
 // Results
 //-----------------------------------------------------------------------
@@ -1297,6 +1370,13 @@ exports.setFailed = setFailed;
 // Logging Commands
 //-----------------------------------------------------------------------
 /**
+ * Gets whether Actions Step Debug is on or not
+ */
+function isDebug() {
+    return process.env['RUNNER_DEBUG'] === '1';
+}
+exports.isDebug = isDebug;
+/**
  * Writes debug message to user log
  * @param message debug message
  */
@@ -1306,18 +1386,18 @@ function debug(message) {
 exports.debug = debug;
 /**
  * Adds an error issue
- * @param message error issue message
+ * @param message error issue message. Errors will be converted to string via toString()
  */
 function error(message) {
-    command_1.issue('error', message);
+    command_1.issue('error', message instanceof Error ? message.toString() : message);
 }
 exports.error = error;
 /**
  * Adds an warning issue
- * @param message warning issue message
+ * @param message warning issue message. Errors will be converted to string via toString()
  */
 function warning(message) {
-    command_1.issue('warning', message);
+    command_1.issue('warning', message instanceof Error ? message.toString() : message);
 }
 exports.warning = warning;
 /**
@@ -1375,8 +1455,9 @@ exports.group = group;
  * Saves state for current action, the state can only be retrieved by this action's post job execution.
  *
  * @param     name     name of the state to store
- * @param     value    value to store
+ * @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
     command_1.issueCommand('save-state', { name }, value);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-containers",
+  "name": "ghcr",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "github-containers",
-  "description": "Build and publish your repository as a Docker image and push it to GitHub Package Registry or GitHub Container Registry in one step",
+  "name": "ghcr",
+  "description": "Build and publish your repository as a Docker image and push it to GitHub Container Registry in one step",
   "main": "index.js",
   "scripts": {
     "package": "ncc build index.js -o dist"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/matootie/github-docker.git"
+    "url": "git+https://github.com/matootie/ghcr.git"
   },
   "keywords": [
     "GitHub",
@@ -18,9 +18,9 @@
   "author": "Mateja Lasan <mateja@lasan.ca> (https://github.com/matootie)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/matootie/github-docker/issues"
+    "url": "https://github.com/matootie/ghcr/issues"
   },
-  "homepage": "https://github.com/matootie/github-docker#readme",
+  "homepage": "https://github.com/matootie/ghcr#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.3"


### PR DESCRIPTION
I'm going to be dropping GitHub Package Registry support and rebranding the repository to `matootie/ghcr`.
