### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ In this example you can see how easy it is to reference the image URL after publ
     tag: ${{ github.sha }}
 
 - name: Print Full Image URL
-  run: echo ${{ stets.publish.outputs.imageURL }}:${{ github.sha }}
+  run: echo ${{ steps.publish.outputs.imageURL }}:${{ github.sha }}
 ```
 
 Otherwise, future steps will end up using the literal tag `latest` for the image and not the customized tag.
@@ -246,7 +246,7 @@ In this example you can see how easy it is to reference the image URL after publ
     containerRegistry: true
 
 - name: Print Full Image URL
-  run: echo ${{ stets.publish.outputs.imageURL }}:${{ github.sha }}
+  run: echo ${{ steps.publish.outputs.imageURL }}:${{ github.sha }}
 ```
 
 Otherwise, future steps will end up using the literal tag `latest` for the image and not the customized tag.


### PR DESCRIPTION
Spotted two minor typos that had `stets` instead of `steps`.